### PR TITLE
Fix return url provided to Hosted Onboarding app

### DIFF
--- a/react-app/src/dashboard/Dashboard.js
+++ b/react-app/src/dashboard/Dashboard.js
@@ -34,7 +34,7 @@ export default function Dashboard() {
     }, []);
 
     const generateOnboardingLink = () => {
-        axios.post('/api/dashboard/getOnboardingLink')
+        axios.post('/api/dashboard/getOnboardingLink', {host: window.location.origin})
           .then((response) => {
             window.location.href = response.data;
           })

--- a/react-app/src/dashboard/Dashboard.js
+++ b/react-app/src/dashboard/Dashboard.js
@@ -34,7 +34,9 @@ export default function Dashboard() {
     }, []);
 
     const generateOnboardingLink = () => {
-        axios.post('/api/dashboard/getOnboardingLink', {host: window.location.origin})
+        axios.post('/api/dashboard/getOnboardingLink', {
+            host: window.location.origin
+          })
           .then((response) => {
             window.location.href = response.data;
           })

--- a/src/main/java/com/adyen/controller/DashboardController.java
+++ b/src/main/java/com/adyen/controller/DashboardController.java
@@ -1,5 +1,6 @@
 package com.adyen.controller;
 
+import com.adyen.model.OnboardingLinkProperties;
 import com.adyen.model.User;
 import com.adyen.model.balanceplatform.AccountHolder;
 import com.adyen.model.legalentitymanagement.LegalEntity;
@@ -7,7 +8,6 @@ import com.adyen.model.legalentitymanagement.OnboardingLink;
 import com.adyen.service.ConfigurationAPIService;
 import com.adyen.service.LegalEntityManagementAPIService;
 import com.adyen.util.LegalEntityHandler;
-import jakarta.servlet.http.HttpServletRequest;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -62,7 +62,7 @@ public class DashboardController extends BaseController {
     }
 
     @PostMapping("/getOnboardingLink")
-    ResponseEntity<String> getOnboardingLink(HttpServletRequest request) {
+    ResponseEntity<String> getOnboardingLink(@RequestBody OnboardingLinkProperties onboardingLinkProperties) {
 
         String legalEntityId;
 
@@ -72,7 +72,7 @@ public class DashboardController extends BaseController {
         }
 
         // get host (used to generate the returnUrl)
-        String host = request.getScheme() + "://" + request.getServerName() + ":" + request.getServerPort();
+        String host = onboardingLinkProperties.getHost();
 
         Optional<AccountHolder> accountHolder = getConfigurationAPIService().getAccountHolder(getUserIdOnSession());
 

--- a/src/main/java/com/adyen/model/OnboardingLinkProperties.java
+++ b/src/main/java/com/adyen/model/OnboardingLinkProperties.java
@@ -1,0 +1,14 @@
+package com.adyen.model;
+
+public class OnboardingLinkProperties {
+
+    private String host;
+
+    public String getHost() {
+        return host;
+    }
+
+    public void setHost(String host) {
+        this.host = host;
+    }
+}


### PR DESCRIPTION
Set the `returnUrl` provided to the Hosted Onboarding app getting the `host` from the frontend (instead of the backend).